### PR TITLE
Implement CPFP into fee rate calculation

### DIFF
--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function getMerkleBranchColumns() {
     const merkleBranchColumns = [];
-    for (let i = 0; i < 11; i++) {
+    for (let i = 0; i < 13; i++) {
       merkleBranchColumns.push({
         title: `<!--<a href="https://github.com/bboerst/stratum-work/blob/main/docs/merkle_branches.md#merkle-tree" target="_blank"><i class="fas fa-question-circle"></i></a><br /> -->Merkle Branch ${i}`,
         field: 'merkle_branches',

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function getMerkleBranchColumns() {
     const merkleBranchColumns = [];
-    for (let i = 0; i < 13; i++) {
+    for (let i = 0; i < 11; i++) {
       merkleBranchColumns.push({
         title: `<!--<a href="https://github.com/bboerst/stratum-work/blob/main/docs/merkle_branches.md#merkle-tree" target="_blank"><i class="fas fa-question-circle"></i></a><br /> -->Merkle Branch ${i}`,
         field: 'merkle_branches',


### PR DESCRIPTION
Closes #2 

1. We send a request to the CPFP API endpoint.
2. If the CPFP API call is successful and the effectiveFeePerVsize is available, we calculate the CPFP fee rate, cache it along with the expiration time, and return it immediately. We don't make the second API call in this case.
3. If the transaction is not a CPFP transaction or the CPFP API call fails, we proceed to make the second API call to calculate the normal fee rate.
4. We send a request to the normal transaction API endpoint and calculate the normal fee rate if the required data is available.