### PR TITLE
Bumping merkle columns to 14 visible in table

### DIFF
--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function getMerkleBranchColumns() {
     const merkleBranchColumns = [];
-    for (let i = 0; i < 11; i++) {
+    for (let i = 0; i < 13; i++) {
       merkleBranchColumns.push({
         title: `<!--<a href="https://github.com/bboerst/stratum-work/blob/main/docs/merkle_branches.md#merkle-tree" target="_blank"><i class="fas fa-question-circle"></i></a><br /> -->Merkle Branch ${i}`,
         field: 'merkle_branches',


### PR DESCRIPTION
While testing, I noticed that a large majority of the time, the merkle branches spill into 13/14 colunmns. Expanding table to show 14 so that observer can see full branch struct.