### PR TITLE
Various updates, including new columns: "Template revision count for block" and "Time since last revision"

### DIFF
--- a/webapp/main.py
+++ b/webapp/main.py
@@ -84,6 +84,14 @@ def process_row_data(row):
         value = tx_out.coin_value / 1e8
         coinbase_outputs.append({"address": address, "value": value})
 
+    current_time = time.time()
+    if 'last_revision_time' not in counters[pool_name]:
+        counters[pool_name]['last_revision_time'] = current_time
+        time_since_last_revision = 0
+    else:
+        time_since_last_revision = current_time - counters[pool_name]['last_revision_time']
+        counters[pool_name]['last_revision_time'] = current_time
+
     processed_row = {
         'pool_name': row['pool_name'],
         'timestamp': row['timestamp'],
@@ -102,7 +110,8 @@ def process_row_data(row):
         'merkle_branches': merkle_branches,
         'merkle_branch_colors': merkle_branch_colors,
         'coinbase_output_value': output_value,
-        'coinbase_outputs': coinbase_outputs
+        'coinbase_outputs': coinbase_outputs,
+        'time_since_last_revision': time_since_last_revision
     }
 
     return processed_row

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -249,6 +249,10 @@ def handle_disconnect():
     except Exception as e:
         logger.warning(f"Error during client disconnect: {e}")
 
+@socketio.on('heartbeat')
+def handle_heartbeat():
+    pass  # Simply acknowledge the heartbeat
+
 def gzip_response(response):
     accept_encoding = request.headers.get('Accept-Encoding', '')
 

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -246,6 +246,8 @@ def handle_disconnect():
     try:
         logger.info('Client disconnected')
         connected_clients.remove(request.sid)
+    except KeyError:
+        logger.info('Client disconnected (already removed)')
     except Exception as e:
         logger.warning(f"Error during client disconnect: {e}")
 

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -169,7 +169,10 @@ def extract_coinbase_script_ascii(coinbase_tx):
     # Get the script_sig in hex from the input of the coinbase transaction
     script_sig_hex = coinbase_tx.txs_in[0].script.hex()
     
-    # Convert the script_sig hex to ASCII and filter out non-printable characters
+    # Remove the first 8 characters (4 bytes) which represent the block height
+    script_sig_hex = script_sig_hex[8:]
+    
+    # Convert the remaining script_sig hex to ASCII and filter out non-printable characters
     return ''.join(filter(lambda x: x in string.printable, bytes.fromhex(script_sig_hex).decode('ascii', 'replace')))
 
 def precompute_merkle_branch_colors(merkle_branches):

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -188,52 +188,66 @@ def precompute_merkle_branch_colors(merkle_branches):
 def hash_code(text):
     return sum(ord(char) for char in text)
 
-def consume_messages():
+def initialize_queue_connection():
     global connection, channel
+    try:
+        credentials = pika.PlainCredentials(rabbitmq_username, rabbitmq_password)
+        connection = pika.BlockingConnection(pika.ConnectionParameters(rabbitmq_host, rabbitmq_port, '/', credentials))
+        channel = connection.channel()
 
-    credentials = pika.PlainCredentials(rabbitmq_username, rabbitmq_password)
-    connection = pika.BlockingConnection(pika.ConnectionParameters(rabbitmq_host, rabbitmq_port, '/', credentials))
-    channel = connection.channel()
+        # Declare the exchange as a fanout exchange
+        channel.exchange_declare(exchange=rabbitmq_exchange, exchange_type='fanout', durable=True)
 
-    # Declare the exchange as a fanout exchange
-    channel.exchange_declare(exchange=rabbitmq_exchange, exchange_type='fanout', durable=True)
+        # Let RabbitMQ generate a unique queue name for each consumer
+        result = channel.queue_declare(queue='', exclusive=True)
+        queue_name = result.method.queue
 
-    # Let RabbitMQ generate a unique queue name for each consumer
-    result = channel.queue_declare(queue='', exclusive=True)
-    queue_name = result.method.queue
+        # Bind the generated queue to the fanout exchange
+        channel.queue_bind(exchange=rabbitmq_exchange, queue=queue_name)
 
-    # Bind the generated queue to the fanout exchange
-    channel.queue_bind(exchange=rabbitmq_exchange, queue=queue_name)
+        logger.info('RabbitMQ connection initialized')
+        return queue_name
+    except Exception as e:
+        logger.exception(f"Error initializing RabbitMQ connection: {e}")
+        return None
 
-    def callback(ch, method, properties, body):
-        try:
-            message = json.loads(body)
-            processed_message = process_row_data(message)
-            for client_id in connected_clients:
-                socketio.emit('mining_data', processed_message, room=client_id)
-        except Exception as e:
-            logger.exception(f"Error processing message: {e}")
+def consume_messages(queue_name):
+    try:
+        def callback(ch, method, properties, body):
+            try:
+                message = json.loads(body)
+                processed_message = process_row_data(message)
+                socketio.emit('mining_data', processed_message, to=None)
+            except Exception as e:
+                logger.exception(f"Error processing message: {e}")
 
-    channel.basic_consume(queue=queue_name, on_message_callback=callback, auto_ack=True)
+        channel.basic_consume(queue=queue_name, on_message_callback=callback, auto_ack=True)
+        logger.info('Started consuming messages from the exchange')
+        channel.start_consuming()
+    except Exception as e:
+        logger.exception(f"Error in consume_messages: {e}")
 
-    logger.info('Started consuming messages from the exchange')
-    channel.start_consuming()
-    
+# Initialize queue connection
+queue_name = initialize_queue_connection()
+if queue_name:
+    # Start consuming messages in a background thread
+    socketio.start_background_task(target=consume_messages, queue_name=queue_name)
+
 @socketio.on('connect')
 def handle_connect():
-    logger.info('Client connected')
-    if len(connected_clients) == 0:
-        socketio.start_background_task(target=consume_messages)
-    connected_clients.add(request.sid)
+    try:
+        logger.info('Client connected')
+        connected_clients.add(request.sid)
+    except Exception as e:
+        logger.warning(f"Error during client connect: {e}")
 
 @socketio.on('disconnect')
 def handle_disconnect():
-    logger.info('Client disconnected')
-    connected_clients.remove(request.sid)
-    if len(connected_clients) == 0:
-        if channel and connection:
-            channel.stop_consuming()
-            connection.close()
+    try:
+        logger.info('Client disconnected')
+        connected_clients.remove(request.sid)
+    except Exception as e:
+        logger.warning(f"Error during client disconnect: {e}")
 
 def gzip_response(response):
     accept_encoding = request.headers.get('Accept-Encoding', '')
@@ -272,6 +286,7 @@ def handle_sigterm(*args):
     logger.info("Received SIGTERM signal. Shutting down gracefully.")
     socketio.stop()
     sys.exit(0)
-    
+
 if __name__ == "__main__":
-    socketio.run(app)
+    signal.signal(signal.SIGTERM, handle_sigterm)
+    socketio.run(app, debug=True, use_reloader=False)

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -47,6 +47,17 @@ rabbitmq_password = os.environ.get('RABBITMQ_PASSWORD')
 rabbitmq_exchange = os.environ.get('RABBITMQ_EXCHANGE')
 
 def process_row_data(row):
+    if 'counters' not in globals():
+        globals()['counters'] = {}
+
+    pool_name = row['pool_name']
+    if pool_name not in counters or counters[pool_name]['height'] != row['height']:
+        counters[pool_name] = {'height': row['height'], 'count': 1}
+    else:
+        counters[pool_name]['count'] += 1
+
+    template_revision = counters[pool_name]['count']
+
     coinbase1 = row['coinbase1']
     coinbase2 = row['coinbase2']
     extranonce1 = row['extranonce1']
@@ -77,6 +88,7 @@ def process_row_data(row):
         'pool_name': row['pool_name'],
         'timestamp': row['timestamp'],
         'height': height,
+        'template_revision': template_revision,
         'prev_block_hash': prev_block_hash,
         'block_version': block_version,
         'coinbase_raw': coinbase_hex,

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -2,7 +2,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function connectWebSocket() {
     const socket = io(SOCKET_URL, {
       reconnection: true,
-      reconnectionAttempts: 5,
+      reconnectionAttempts: Infinity,
       reconnectionDelay: 1000,
       reconnectionDelayMax: 5000,
       randomizationFactor: 0.5,
@@ -10,17 +10,45 @@ document.addEventListener('DOMContentLoaded', () => {
 
     socket.on('connect', () => {
       console.log('WebSocket connected');
+      hideReconnectionMessage();
     });
 
     socket.on('disconnect', (reason) => {
       console.log('WebSocket disconnected:', reason);
+      showReconnectionMessage();
     });
 
     socket.on('connect_error', (error) => {
       console.error('WebSocket connection error:', error);
+      showReconnectionMessage();
     });
 
     return socket;
+  }
+
+  function showReconnectionMessage() {
+    const message = document.getElementById('reconnection-message');
+    if (!message) {
+      const newMessage = document.createElement('div');
+      newMessage.id = 'reconnection-message';
+      newMessage.innerHTML = 'Attempting to reconnect...';
+      newMessage.style.position = 'fixed';
+      newMessage.style.top = '10px';
+      newMessage.style.right = '10px';
+      newMessage.style.backgroundColor = 'rgba(255, 0, 0, 0.7)';
+      newMessage.style.color = 'white';
+      newMessage.style.padding = '10px';
+      newMessage.style.borderRadius = '5px';
+      newMessage.style.zIndex = '1000';
+      document.body.appendChild(newMessage);
+    }
+  }
+
+  function hideReconnectionMessage() {
+    const message = document.getElementById('reconnection-message');
+    if (message) {
+      message.remove();
+    }
   }
 
   const socket = connectWebSocket();

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -60,6 +60,20 @@ document.addEventListener('DOMContentLoaded', () => {
         visible: true,
       },
       {
+        title: 'Time Since Last Revision',
+        field: 'time_since_last_revision',
+        width: 85,
+        sorter: 'number',
+        formatter: function(cell) {
+          const value = cell.getValue();
+          if (value === undefined || value === null) return '';
+          const seconds = Math.floor(value);
+          const milliseconds = Math.round((value - seconds) * 1000);
+          return `${seconds}.${milliseconds.toString().padStart(3, '0')}s`;
+        },
+        visible: true,
+      },
+      {
         title: '<!--<a href="https://github.com/bboerst/stratum-work/blob/main/docs/timestamp.md" target="_blank"><i class="fas fa-question-circle"></i></a><br /> -->Timestamp',
         field: 'timestamp',
         sorter: function (a, b, aRow, bRow, column, dir, sorterParams) {
@@ -88,7 +102,6 @@ document.addEventListener('DOMContentLoaded', () => {
               .filter(output => !output.address.includes("nulldata"))
               .map(output => `${output.address}:${output.value}`)
               .join('|');
-            
             const color = generateColorFromOutputs(outputs);
             cell.getElement().style.backgroundColor = color;
             cell.getElement().style.whiteSpace = 'nowrap';

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -53,6 +53,13 @@ document.addEventListener('DOMContentLoaded', () => {
         width: 130,
       },
       {
+        title: 'Template Revision',
+        field: 'template_revision',
+        width: 100,
+        sorter: 'number',
+        visible: true,
+      },
+      {
         title: '<!--<a href="https://github.com/bboerst/stratum-work/blob/main/docs/timestamp.md" target="_blank"><i class="fas fa-question-circle"></i></a><br /> -->Timestamp',
         field: 'timestamp',
         sorter: function (a, b, aRow, bRow, column, dir, sorterParams) {

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -53,16 +53,16 @@ document.addEventListener('DOMContentLoaded', () => {
         width: 130,
       },
       {
-        title: 'Template Revision',
+        title: 'Template Revision for Current Block',
         field: 'template_revision',
         width: 50,
         sorter: 'number',
         visible: true,
       },
       {
-        title: 'Time Since Last Revision',
+        title: 'Time Since Last Template Revision',
         field: 'time_since_last_revision',
-        width: 85,
+        width: 80,
         sorter: 'number',
         formatter: function(cell) {
           const value = cell.getValue();

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
       {
         title: 'Template Revision',
         field: 'template_revision',
-        width: 100,
+        width: 50,
         sorter: 'number',
         visible: true,
       },

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -233,6 +233,17 @@
             animation: flash-border 1s infinite;
             border: 2px solid red;
         }
+
+        #reconnection-message {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            background-color: rgba(255, 0, 0, 0.7);
+            color: white;
+            padding: 10px;
+            border-radius: 5px;
+            z-index: 1000;
+        }
     </style>
 </head>
 

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -233,6 +233,11 @@
             animation: flash-border 1s infinite;
             border: 2px solid red;
         }
+
+        .tabulator .tabulator-col[tabulator-field="template_revision"] .tabulator-col-title::after {
+            content: " ℹ️";
+            cursor: help;
+        }
     </style>
 </head>
 
@@ -259,6 +264,24 @@
 
     <div id="mining-table"></div>
     <div id="loading-message">Wait for new stratum messages...</div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    if (mutation.type === 'childList') {
+                        const templateRevisionHeader = document.querySelector('.tabulator-col[tabulator-field="template_revision"] .tabulator-col-title');
+                        if (templateRevisionHeader) {
+                            templateRevisionHeader.setAttribute('title', 'Number of template revisions for this pool in the current block');
+                            observer.disconnect();
+                        }
+                    }
+                });
+            });
+
+            observer.observe(document.body, { childList: true, subtree: true });
+        });
+    </script>
 </body>
 
 </html>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -233,11 +233,6 @@
             animation: flash-border 1s infinite;
             border: 2px solid red;
         }
-
-        .tabulator .tabulator-col[tabulator-field="template_revision"] .tabulator-col-title::after {
-            content: " ℹ️";
-            cursor: help;
-        }
     </style>
 </head>
 
@@ -264,24 +259,6 @@
 
     <div id="mining-table"></div>
     <div id="loading-message">Wait for new stratum messages...</div>
-
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const observer = new MutationObserver((mutations) => {
-                mutations.forEach((mutation) => {
-                    if (mutation.type === 'childList') {
-                        const templateRevisionHeader = document.querySelector('.tabulator-col[tabulator-field="template_revision"] .tabulator-col-title');
-                        if (templateRevisionHeader) {
-                            templateRevisionHeader.setAttribute('title', 'Number of template revisions for this pool in the current block');
-                            observer.disconnect();
-                        }
-                    }
-                });
-            });
-
-            observer.observe(document.body, { childList: true, subtree: true });
-        });
-    </script>
 </body>
 
 </html>


### PR DESCRIPTION
Resolves #13 

Lots of good updates...

### 2 new columns:
- A counter for each pool that increments with each new template revision received. Counter resets every block. Called "Template Revision for Current Block". This could show correlation between pools and the number/rate of template revisions for a block.
- Column that shows the time in seconds and milliseconds between the previous revision and the current revision. Could show correlation between pools from a timing perspective. How long since the last template was sent?

### ASCII pool identifier improvement
The first 4 bytes of script sig are always the 'block height', so might as well chop those off before ASCII-fying it. This will resolve sometimes where every pool had the same first character in the ASCII column.

### Refactor app-startup connection logic
Now when the app starts, it'll start consuming queue events right away, rather than waiting for the first client to connect. This is helpful for the new `Template Revision for Current Block` column because when running this app with multiple replicas, each replica/instance will have accurate counters.

### Attempting to fix session issue where client needs to clear cookies
Adds WebSocket reconnection logic with exponential backoff, adds error handling for connection issues, and introduces a heartbeat mechanism to detect and recover from silent failures.