### PR TITLE
Remove the ephemeral (random) queue logic and instead use one named, per-pod queue in fanout mode

### DIFF
--- a/helm-charts/stratum-work-webapp/Chart.yaml
+++ b/helm-charts/stratum-work-webapp/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 description: Web frontend/backend for Pool Work
 name: stratum-work-webapp
-version: 0.1.7
+version: 0.1.8
 # renovate: image=bboerst/stratum-work-webapp
 appVersion: "v1.0.7"

--- a/helm-charts/stratum-work-webapp/templates/podmonitor.yaml
+++ b/helm-charts/stratum-work-webapp/templates/podmonitor.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.podmonitor.enabled }}
+{{- $fullName := include "stratum-work-webapp.fullname" . -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    {{- include "stratum-work-webapp.labels" . | nindent 4 }}
+    {{- if .Values.podmonitor.labels }}
+    {{- .Values.podmonitor.labels | toYaml | nindent 4 }}
+    {{- end }}
+  name: {{ $fullName }}
+  namespace: {{ template "stratum-work-webapp.namespace" . }}
+spec:
+  namespaceSelector:
+    matchNames:
+    - {{ template "stratum-work-webapp.namespace" . }}
+  podMetricsEndpoints:
+  - port: flask
+  selector:
+    matchLabels:
+      app: {{ template "stratum-work-webapp.fullname" . }}
+{{- end -}}

--- a/helm-charts/stratum-work-webapp/values.yaml
+++ b/helm-charts/stratum-work-webapp/values.yaml
@@ -9,6 +9,10 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+podmonitor:
+  enabled: false
+  labels: {}
+
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -4,6 +4,7 @@ Flask-SocketIO==5.3.6
 Flask==3.0.3
 gunicorn==22.0.0
 pika==1.3.2
+prometheus_client==0.21.1
 pycoin==0.92.20230326
 pymongo==4.7.2
 requests==2.32.3


### PR DESCRIPTION
This should resolve the issue with some clients getting stuck with a blank table (no more websocket updates coming from server).

This change removes the ephemeral (random) queue logic and instead uses one named, per-pod queue in fanout mode. This way, each replica receives every message from the exchange. Each replica can then broadcast messages to its own Socket.IO clients without relying on sticky sessions for ephemeral queues.

Also adding light prometheus instrumentation to get an active client counter.
