### PR TITLE
Fix Coinbase Output sorting logic

### DIFF
--- a/web/hooks/useTableData.ts
+++ b/web/hooks/useTableData.ts
@@ -3,6 +3,7 @@ import { StratumV1Data, StreamDataType } from '@/lib/types';
 import { SortedRow, SortConfig, SortDirection } from '@/types/tableTypes';
 import { formatCoinbaseRaw } from '@/utils/formatters';
 import { formatCoinbaseScriptASCII, computeCoinbaseOutputValue, computeFirstTransaction, computeCoinbaseOutputs, fetchFeeRate, clearCoinbaseFromCaches, isRequestInFlight, markRequestInFlight, clearRequestInFlight } from '@/utils/bitcoinUtils';
+import { sortRowsByKey } from '@/utils/sortUtils';
 
 // Constants for pagination
 const ITEMS_PER_PAGE = 50;
@@ -437,41 +438,8 @@ export function useTableData(
       // This ensures consistency between the UI and the actual sorting
       const direction = sortConfig ? sortConfig.direction : "desc" as SortDirection;
       
-      // Sort the entire dataset
-      const sortedAllData = [...allData].sort((a, b) => {
-        const aValue = a[key];
-        const bValue = b[key];
-        
-        if (aValue === undefined || aValue === null) return 1;
-        if (bValue === undefined || bValue === null) return -1;
-        
-        if (typeof aValue === 'number' && typeof bValue === 'number') {
-          return direction === "asc" ? aValue - bValue : bValue - aValue;
-        }
-        
-        // For date strings (like timestamp)
-        if (key === "timestamp") {
-          // Check if we're dealing with ISO date strings or hex timestamps
-          const aString = String(aValue);
-          const bString = String(bValue);
-          
-          if (aString.includes('-') && bString.includes('-')) {
-            // These are ISO date strings
-            const dateA = new Date(aString).getTime();
-            const dateB = new Date(bString).getTime();
-            return direction === "asc" ? dateA - dateB : dateB - dateA;
-          }
-          
-          // Otherwise, compare as strings
-          return direction === "asc" ? aString.localeCompare(bString) : bString.localeCompare(aString);
-        }
-        
-        // For other string values
-        const aString = String(aValue);
-        const bString = String(bValue);
-        
-        return direction === "asc" ? aString.localeCompare(bString) : bString.localeCompare(aString);
-      });
+      // Sort the entire dataset using our shared utility function
+      const sortedAllData = sortRowsByKey(allData, key, direction);
       
       // Reset pagination to show the first page
       setPage(1);

--- a/web/hooks/useTableState.ts
+++ b/web/hooks/useTableState.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { StratumV1Data } from '@/lib/types';
 import { SortedRow, SortDirection, SortConfig, ColumnWidths } from '@/types/tableTypes';
+import { sortRowsByKey } from '@/utils/sortUtils';
 
 // Hook for managing column visibility
 export function useColumnVisibility() {
@@ -155,42 +156,8 @@ export function useSorting(isFiltering: boolean) {
   const sortData = useCallback((data: SortedRow[]) => {
     if (!data || data.length === 0) return [];
     
-    return [...data].sort((a, b) => {
-      const aValue = a[sortConfig.key];
-      const bValue = b[sortConfig.key];
-      
-      if (aValue === undefined || aValue === null) return 1;
-      if (bValue === undefined || bValue === null) return -1;
-      
-      if (typeof aValue === 'number' && typeof bValue === 'number') {
-        return sortConfig.direction === "asc" ? aValue - bValue : bValue - aValue;
-      }
-      
-      // For date strings (like timestamp)
-      if (sortConfig.key === "timestamp") {
-        // Check if we're dealing with ISO date strings or hex timestamps
-        const aString = String(aValue);
-        const bString = String(bValue);
-        
-        if (aString.includes('-') && bString.includes('-')) {
-          // These are ISO date strings
-          const dateA = new Date(aString).getTime();
-          const dateB = new Date(bString).getTime();
-          return sortConfig.direction === "asc" ? dateA - dateB : dateB - dateA;
-        }
-        
-        // Otherwise, compare as strings
-        return sortConfig.direction === "asc" ? aString.localeCompare(bString) : bString.localeCompare(aString);
-      }
-      
-      // For other string values
-      const aString = String(aValue);
-      const bString = String(bValue);
-      
-      return sortConfig.direction === "asc" 
-        ? aString.localeCompare(bString) 
-        : bString.localeCompare(aString);
-    });
+    // Using our shared sortRowsByKey utility function
+    return sortRowsByKey(data, sortConfig.key, sortConfig.direction);
   }, [sortConfig]);
 
   return {

--- a/web/utils/sortUtils.ts
+++ b/web/utils/sortUtils.ts
@@ -1,0 +1,127 @@
+import { SortedRow, SortDirection, SortConfig } from "@/types/tableTypes";
+
+/**
+ * Sort coinbase outputs by address more efficiently
+ */
+export function sortCoinbaseOutputs(
+  aValue: any, 
+  bValue: any, 
+  direction: SortDirection
+): number {
+  // Convert outputs to sort keys (once per comparison)
+  const getSortKey = (outputs: any[]): string => {
+    if (!Array.isArray(outputs) || outputs.length === 0) return '';
+    
+    // Extract and join valid addresses with a separator
+    return outputs
+      .filter(o => typeof o === 'object' && o !== null && 'address' in o && !o.address.includes('nulldata'))
+      .map(o => o.address)
+      .join('|'); // Using pipe as it's unlikely to appear in addresses
+  };
+  
+  // Generate sort keys just once per comparison
+  const aKey = getSortKey(aValue as any[]);
+  const bKey = getSortKey(bValue as any[]);
+  
+  // Simple string comparison on the sort keys
+  return direction === "asc" 
+    ? aKey.localeCompare(bKey) 
+    : bKey.localeCompare(aKey);
+}
+
+/**
+ * Sort timestamp strings
+ */
+export function sortTimestamps(
+  aValue: any,
+  bValue: any,
+  direction: SortDirection
+): number {
+  const aString = String(aValue);
+  const bString = String(bValue);
+  
+  if (aString.includes('-') && bString.includes('-')) {
+    // These are ISO date strings
+    const dateA = new Date(aString).getTime();
+    const dateB = new Date(bString).getTime();
+    return direction === "asc" ? dateA - dateB : dateB - dateA;
+  }
+  
+  // Otherwise, compare as strings
+  return direction === "asc" ? aString.localeCompare(bString) : bString.localeCompare(aString);
+}
+
+/**
+ * Generic function to sort rows by a key
+ */
+export function sortRowsByKey<T extends Record<string, any>>(
+  data: T[],
+  key: keyof T,
+  direction: SortDirection
+): T[] {
+  // For coinbase_outputs, we can optimize by precomputing sort keys for the entire dataset
+  if (key === "coinbase_outputs" && data.length > 0) {
+    // Create a Map to store sort keys for each item
+    const sortKeyMap = new Map<T, string>();
+    
+    // Precompute sort keys for all items
+    for (const item of data) {
+      const outputs = item[key];
+      if (!Array.isArray(outputs) || outputs.length === 0) {
+        sortKeyMap.set(item, '');
+        continue;
+      }
+      
+      // Extract and join valid addresses
+      const sortKey = outputs
+        .filter((o: any) => typeof o === 'object' && o !== null && 'address' in o && !o.address.includes('nulldata'))
+        .map((o: any) => o.address)
+        .join('|');
+      
+      sortKeyMap.set(item, sortKey);
+    }
+    
+    // Sort using the precomputed keys (much faster)
+    return [...data].sort((a, b) => {
+      const aKey = sortKeyMap.get(a) || '';
+      const bKey = sortKeyMap.get(b) || '';
+      
+      return direction === "asc" 
+        ? aKey.localeCompare(bKey) 
+        : bKey.localeCompare(aKey);
+    });
+  }
+  
+  // For other keys, use the regular comparison logic
+  return [...data].sort((a, b) => {
+    const aValue = a[key];
+    const bValue = b[key];
+    
+    // Handle null/undefined values
+    if (aValue === undefined || aValue === null) return 1;
+    if (bValue === undefined || bValue === null) return -1;
+    
+    // Special case for coinbase_outputs when not using the optimization above
+    if (key === "coinbase_outputs") {
+      return sortCoinbaseOutputs(aValue, bValue, direction);
+    }
+    
+    // Numeric values
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return direction === "asc" ? aValue - bValue : bValue - aValue;
+    }
+    
+    // Timestamp handling
+    if (key === "timestamp") {
+      return sortTimestamps(aValue, bValue, direction);
+    }
+    
+    // String values (default case)
+    const aString = String(aValue);
+    const bString = String(bValue);
+    
+    return direction === "asc" 
+      ? aString.localeCompare(bString) 
+      : bString.localeCompare(aString);
+  });
+} 


### PR DESCRIPTION
Fixes #37 

- Fixed sorting: The "Coinbase Outputs" column now properly sorts based on all addresses in each output
- Extracted shared sorting logic from both useTableState.ts and useTableData.ts into a new util file