### PR TITLE
Enable collector to run standalone

### DIFF
--- a/collector/main.py
+++ b/collector/main.py
@@ -1,13 +1,11 @@
 import argparse
 import json
 import logging
-import os
 import socket
 import sys
 import time
 import uuid
 from datetime import datetime
-from distutils.util import strtobool
 from urllib.parse import urlparse
 import select
 
@@ -19,7 +17,7 @@ import socks
 LOG = logging.getLogger()
 
 class Watcher:
-    def __init__(self, url, userpass, pool_name, rabbitmq_host, rabbitmq_port, rabbitmq_username, rabbitmq_password, rabbitmq_exchange, db_url, db_name, db_username, db_password, enable_historical_data, use_proxy=False, proxy_host=None, proxy_port=None, enable_stratum_client=False, stratum_client_port=None):
+    def __init__(self, url, userpass, pool_name, rabbitmq_host, rabbitmq_port, rabbitmq_username, rabbitmq_password, rabbitmq_exchange, db_url, db_name, db_username, db_password, use_proxy=False, proxy_host=None, proxy_port=None, enable_stratum_client=False, stratum_client_port=None, rabbitmq_enabled=True, db_enabled=True):
         self.buf = b""
         self.id = 1
         self.userpass = userpass
@@ -30,14 +28,17 @@ class Watcher:
         self.rabbitmq_username = rabbitmq_username
         self.rabbitmq_password = rabbitmq_password
         self.rabbitmq_exchange = rabbitmq_exchange
+        self.rabbitmq_enabled = rabbitmq_enabled
         self.db_url = db_url
         self.db_name = db_name
         self.db_username = db_username
         self.db_password = db_password
-        self.enable_historical_data = enable_historical_data
+        self.db_enabled = db_enabled
         self.purl = self.parse_url(url)
         self.extranonce1 = None
         self.extranonce2_length = -1
+        self.pending_notifications = []
+        self.current_difficulty = None
         self.use_proxy = use_proxy
         self.proxy_host = proxy_host
         self.proxy_port = proxy_port
@@ -88,13 +89,17 @@ class Watcher:
         self.sock = None
 
     def get_msg(self):
+        """Return (parsed_msg, receipt_ts_ns). Timestamp is captured at the
+        earliest moment a complete line is available, before JSON parsing."""
+        receipt_ts_ns = None
         while True:
             split_buf = self.buf.split(b"\n", maxsplit=1)
             r = split_buf[0]
             if r == b'':
-                # If r is an empty byte string, continue reading data from the socket
                 try:
                     new_buf = self.sock.recv(4096)
+                    if receipt_ts_ns is None:
+                        receipt_ts_ns = time.time_ns()
                 except Exception as e:
                     LOG.debug(f"Error receiving data: {e}")
                     raise EOFError
@@ -102,15 +107,17 @@ class Watcher:
                     raise EOFError
                 self.buf += new_buf
                 continue
+            if receipt_ts_ns is None:
+                receipt_ts_ns = time.time_ns()
             try:
                 resp = json.loads(r)
                 if len(split_buf) == 2:
                     self.buf = split_buf[1]
                 else:
                     self.buf = b""
-                return resp
+                return resp, receipt_ts_ns
             except (json.decoder.JSONDecodeError, ConnectionResetError) as e:
-                LOG.debug(f"Error decoding JSON: {e}")
+                LOG.debug(f"Error decoding JSON: {e} | raw ({len(r)} bytes): {r[:500]}")
                 new_buf = b""
                 try:
                     new_buf = self.sock.recv(4096)
@@ -122,8 +129,9 @@ class Watcher:
                 self.buf += new_buf
 
     def send_jsonrpc(self, method, params):
+        request_id = self.id
         data = {
-            "id": self.id,
+            "id": request_id,
             "method": method,
             "params": params,
         }
@@ -133,14 +141,13 @@ class Watcher:
         json_data = json.dumps(data) + "\n"
         self.sock.send(json_data.encode())
 
-        resp = self.get_msg()
-        LOG.debug(f"Received: {resp}")
-
-        # If we just called mining.subscribe, we expect the last two items in 'result'
-        # to be extranonce1 and extranonce2_size, respectively.
-        if method == "mining.subscribe" and resp.get("result") is not None:
-            self.extranonce1, self.extranonce2_length = resp["result"][-2:]
-            LOG.debug(f"Extracted extranonce1={self.extranonce1} extranonce2_length={self.extranonce2_length}")
+        while True:
+            msg, ts = self.get_msg()
+            if isinstance(msg, dict) and msg.get("id") == request_id:
+                LOG.debug(f"Received response for request {request_id}: {msg}")
+                return msg
+            LOG.info(f"Queued server notification while awaiting response {request_id}: {msg}")
+            self.pending_notifications.append((msg, ts))
 
     def connect_to_rabbitmq(self):
         for attempt in range(self.max_retries):
@@ -182,12 +189,21 @@ class Watcher:
 
                 if not self.enable_stratum_client:
                     LOG.info("Sending mining.subscribe request")
-                    self.send_jsonrpc("mining.subscribe", [])
-                    LOG.info("Successfully subscribed to pool notifications")
+                    sub_resp = self.send_jsonrpc("mining.subscribe", [])
+                    if sub_resp.get("error"):
+                        LOG.warning(f"Subscribe error from pool: {sub_resp}")
+                    if sub_resp.get("result") is not None:
+                        self.extranonce1, self.extranonce2_length = sub_resp["result"][-2:]
+                        LOG.info(f"Subscribed: extranonce1={self.extranonce1} extranonce2_length={self.extranonce2_length}")
+                    else:
+                        LOG.warning(f"Subscribe response missing result: {sub_resp}")
 
                     LOG.info("Sending mining.authorize request")
-                    self.send_jsonrpc("mining.authorize", self.userpass.split(":"))
-                    LOG.info("Successfully authorized with the pool")
+                    auth_resp = self.send_jsonrpc("mining.authorize", self.userpass.split(":"))
+                    if auth_resp.get("result") is True:
+                        LOG.info("Successfully authorized with the pool")
+                    else:
+                        LOG.warning(f"Authorization rejected by pool: {auth_resp}")
                 return
             except Exception as e:
                 LOG.error(f"Failed to connect to stratum server (attempt {attempt + 1}/{self.max_retries}): {e}")
@@ -197,6 +213,30 @@ class Watcher:
                 else:
                     raise
 
+    def _drain_pending_notifications(self):
+        for msg, ts in self.pending_notifications:
+            self._process_notification(msg, None, ts)
+        self.pending_notifications.clear()
+
+    def _process_notification(self, msg, raw_bytes, receipt_ts_ns):
+        method = msg.get("method") if isinstance(msg, dict) else None
+        if method == "mining.notify":
+            event_time = hex(receipt_ts_ns)[2:]
+            LOG.info(f"mining.notify job_id={msg['params'][0]} prev_hash={msg['params'][1][:16]}... clean={msg['params'][8]}")
+            LOG.debug(f"mining.notify full payload: {msg}")
+            document = create_notification_document(msg, self.pool_name, self.extranonce1, self.extranonce2_length, event_time)
+            if self.db_enabled:
+                insert_notification(document, self.db_url, self.db_name, self.db_username, self.db_password)
+            if self.rabbitmq_enabled:
+                self.publish_to_rabbitmq(document)
+        elif method == "mining.set_difficulty":
+            self.current_difficulty = msg.get("params", [None])[0]
+            LOG.info(f"mining.set_difficulty: {self.current_difficulty}")
+        elif method:
+            LOG.info(f"Server notification: {method} params={msg.get('params')}")
+        else:
+            LOG.debug(f"Non-notification message: {msg}")
+
     def get_stratum_work(self, keep_alive=False):
         LOG.info("Starting get_stratum_work")
         last_subscribe_time = time.time()
@@ -204,18 +244,9 @@ class Watcher:
             try:
                 if not self.sock:
                     self.connect_to_stratum()
-                n = self.get_msg()
-                event_time = hex(time.time_ns())[2:]
-                LOG.debug(f"Received notification: {n}")
-                if "method" in n and n["method"] == "mining.notify":
-                    LOG.info("Received mining.notify message")
-                    document = create_notification_document(n, self.pool_name, self.extranonce1, self.extranonce2_length, event_time)
-                    if self.enable_historical_data:
-                        LOG.info("Historical data enabled, inserting notification to DB")
-                        insert_notification(document, self.db_url, self.db_name, self.db_username, self.db_password)
-                    else:
-                        LOG.info("Historical data disabled, skipping DB insert")
-                    self.publish_to_rabbitmq(document)
+                    self._drain_pending_notifications()
+                n, receipt_ts = self.get_msg()
+                self._process_notification(n, None, receipt_ts)
                 if keep_alive and time.time() - last_subscribe_time > 480:
                     LOG.info("Keep-alive interval reached")
                     self.send_jsonrpc("mining.subscribe", [])
@@ -226,11 +257,13 @@ class Watcher:
                 self.close()
                 time.sleep(self.retry_delay)
                 self.connect_to_stratum()
+                self._drain_pending_notifications()
             except Exception as e:
                 LOG.error(f"Unexpected error: {e}")
                 self.close()
                 time.sleep(self.retry_delay)
                 self.connect_to_stratum()
+                self._drain_pending_notifications()
 
     def run_proxy(self, client_socket):
         """
@@ -249,6 +282,7 @@ class Watcher:
             if self.sock in rlist:
                 try:
                     data = self.sock.recv(4096)
+                    recv_ts = time.time_ns()
                 except Exception as e:
                     LOG.error(f"Error receiving from pool: {e}")
                     break
@@ -264,12 +298,8 @@ class Watcher:
                         msg = json.loads(line)
                     except Exception as e:
                         msg = None
-                    if msg and msg.get("method") == "mining.notify":
-                        LOG.info("Received mining.notify message from pool (via proxy)")
-                        event_time = hex(time.time_ns())[2:]
-                        document = create_notification_document(msg, self.pool_name, self.extranonce1, self.extranonce2_length, event_time)
-                        insert_notification(document, self.db_url, self.db_name, self.db_username, self.db_password)
-                        self.publish_to_rabbitmq(document)
+                    if msg:
+                        self._process_notification(msg, line, recv_ts)
                     if msg and "result" in msg and isinstance(msg["result"], list) and len(msg["result"]) >= 2:
                         self.extranonce1 = msg["result"][-2]
                         self.extranonce2_length = msg["result"][-1]
@@ -347,7 +377,7 @@ def main():
         "-up", "--userpass", required=True, help="Username and password combination separated by a colon (:)"
     )
     parser.add_argument(
-        "-p", "--pool-name", required=True, help="The name of the pool"
+        "-p", "--pool-name", default=None, help="The name of the pool (defaults to hostname from --url)"
     )
     parser.add_argument(
         "-r", "--rabbitmq-host", default="localhost", help="The hostname or IP address of the RabbitMQ server (default: localhost)"
@@ -356,10 +386,10 @@ def main():
         "-rpc", "--rabbitmq-port", default=5672, help="The port of the RabbitMQ server (default: 5672)"
     )
     parser.add_argument(
-        "-ru", "--rabbitmq-username", required=True, help="The username for RabbitMQ authentication"
+        "-ru", "--rabbitmq-username", default=None, help="The username for RabbitMQ authentication"
     )
     parser.add_argument(
-        "-rp", "--rabbitmq-password", required=True, help="The password for RabbitMQ authentication"
+        "-rp", "--rabbitmq-password", default=None, help="The password for RabbitMQ authentication"
     )
     parser.add_argument(
         "-re", "--rabbitmq-exchange", default="mining_notify_exchange", help="The name of the RabbitMQ exchange (default: mining_notify_exchange)"
@@ -371,10 +401,10 @@ def main():
         "-dn", "--db-name", default="stratum-logger", help="MongoDB database name"
     )
     parser.add_argument(
-        "-du", "--db-username", required=True, help="MongoDB username"
+        "-du", "--db-username", default=None, help="MongoDB username"
     )
     parser.add_argument(
-        "-dp", "--db-password", required=True, help="MongoDB password"
+        "-dp", "--db-password", default=None, help="MongoDB password"
     )
     parser.add_argument(
         "-k", "--keep-alive", action="store_true", help="Enable sending periodic subscribe requests to keep the connection alive"
@@ -400,13 +430,11 @@ def main():
     )
     args = parser.parse_args()
 
-    # Read env var for historical data
-    enable_historical_data_str = os.getenv('ENABLE_HISTORICAL_DATA', 'true')
-    try:
-        enable_historical_data = bool(strtobool(enable_historical_data_str))
-    except ValueError:
-        LOG.error(f"Invalid value for ENABLE_HISTORICAL_DATA: {enable_historical_data_str}. Defaulting to True.")
-        enable_historical_data = True
+    if args.pool_name is None:
+        args.pool_name = urlparse(args.url).hostname
+
+    rabbitmq_enabled = args.rabbitmq_username is not None and args.rabbitmq_password is not None
+    db_enabled = args.db_username is not None and args.db_password is not None
 
     log_level = getattr(logging, args.log_level.upper(), None)
     if not isinstance(log_level, int):
@@ -418,7 +446,16 @@ def main():
         level=log_level,
     )
     LOG.info(f"Logging level set to {args.log_level.upper()}")
-    LOG.info(f"Historical data feature enabled: {enable_historical_data}")
+    LOG.info(f"Pool name: {args.pool_name}")
+    backends = []
+    if rabbitmq_enabled:
+        backends.append("RabbitMQ")
+    if db_enabled:
+        backends.append("MongoDB")
+    if backends:
+        LOG.info(f"Enabled backends: {', '.join(backends)}")
+    else:
+        LOG.info("Running in connect-only mode (no RabbitMQ or MongoDB backends enabled)")
 
     if args.enable_stratum_client:
         server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -434,11 +471,12 @@ def main():
                     args.url, args.userpass, args.pool_name,
                     args.rabbitmq_host, args.rabbitmq_port, args.rabbitmq_username, args.rabbitmq_password, args.rabbitmq_exchange,
                     args.db_url, args.db_name, args.db_username, args.db_password,
-                    enable_historical_data,
                     args.use_proxy, args.proxy_host, args.proxy_port,
-                    enable_stratum_client=True, stratum_client_port=args.stratum_client_port
+                    enable_stratum_client=True, stratum_client_port=args.stratum_client_port,
+                    rabbitmq_enabled=rabbitmq_enabled, db_enabled=db_enabled
                 )
-                w.connect_to_rabbitmq()
+                if rabbitmq_enabled:
+                    w.connect_to_rabbitmq()
                 w.connect_to_stratum()
                 w.run_proxy(client_conn)
             except KeyboardInterrupt:
@@ -448,7 +486,7 @@ def main():
             finally:
                 try:
                     w.close()
-                    if w.connection:
+                    if rabbitmq_enabled and w.connection:
                         w.connection.close()
                 except Exception:
                     pass
@@ -463,18 +501,19 @@ def main():
                 args.url, args.userpass, args.pool_name,
                 args.rabbitmq_host, args.rabbitmq_port, args.rabbitmq_username, args.rabbitmq_password, args.rabbitmq_exchange,
                 args.db_url, args.db_name, args.db_username, args.db_password,
-                enable_historical_data,
                 args.use_proxy, args.proxy_host, args.proxy_port,
-                enable_stratum_client=False
+                enable_stratum_client=False,
+                rabbitmq_enabled=rabbitmq_enabled, db_enabled=db_enabled
             )
             try:
-                w.connect_to_rabbitmq()
+                if rabbitmq_enabled:
+                    w.connect_to_rabbitmq()
                 w.get_stratum_work(keep_alive=args.keep_alive)
             except KeyboardInterrupt:
                 break
             finally:
                 w.close()
-                if w.connection:
+                if rabbitmq_enabled and w.connection:
                     w.connection.close()
 
 if __name__ == "__main__":

--- a/collector/main.py
+++ b/collector/main.py
@@ -360,7 +360,12 @@ def create_notification_document(data, pool_name, extranonce1, extranonce2_lengt
 
 def insert_notification(document, db_url, db_name, db_username, db_password):
     LOG.debug(f"Attempting to insert document into MongoDB: {document}")
-    client = MongoClient(f"mongodb://{db_username}:{db_password}@{db_url}")
+    host = db_url
+    for prefix in ("mongodb+srv://", "mongodb://"):
+        if host.startswith(prefix):
+            host = host[len(prefix):]
+            break
+    client = MongoClient(f"mongodb://{db_username}:{db_password}@{host}")
     db = client[db_name]
     collection = db["mining_notify"]
     result = collection.insert_one(document)


### PR DESCRIPTION
Now `collector` can be run as a tool to test connecting to a stratum server as a standalone script; useful for troubleshooting and raw stratum message monitoring:

```
# python3 ./collector/main.py --url stratum+tcp://miningpool.com:3333 --userpass user1:x --log-level DEBUG
```

Also bumping the `receipt_ts` timestamp a bit sooner in the processing pipeline.