### PR TITLE
Chain divergence detection

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -332,7 +332,9 @@ def run_block_analyses(height: int, coinbase_script_hex: str | None = None, coin
     analysis: Dict[str, Any] = {}
     logger.info("Running analyses for height %d", height)
     try:
-        templates = list(db.mining_notify.find({"height": height})) if db is not None else []
+        templates = list(
+            db.mining_notify.find({"height": height, "chain_family": {"$exists": False}})
+        ) if db is not None else []
     except Exception as e:
         logger.error(f"Error fetching mining.notify templates for height {height}: {e}")
         templates = []

--- a/backend/tests/test_btc_template_filtering.py
+++ b/backend/tests/test_btc_template_filtering.py
@@ -1,0 +1,109 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+class FakeMiningNotifyCollection:
+    def __init__(self):
+        self.queries = []
+
+    def find(self, query):
+        self.queries.append(query)
+        return []
+
+
+class FakeDB:
+    def __init__(self):
+        self.mining_notify = FakeMiningNotifyCollection()
+
+
+class FakeRPCConnection:
+    def getblockcount(self):
+        return 0
+
+
+class FakeAuthServiceProxy:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def getblockcount(self):
+        return 0
+
+
+def import_main_module():
+    fake_db = FakeDB()
+
+    bitcoinrpc_module = types.ModuleType("bitcoinrpc")
+    authproxy_module = types.ModuleType("bitcoinrpc.authproxy")
+    authproxy_module.AuthServiceProxy = FakeAuthServiceProxy
+    bitcoinrpc_module.authproxy = authproxy_module
+
+    integrations_module = types.ModuleType("integrations")
+    integrations_module.db = fake_db
+    integrations_module.blocks_coll = object()
+    integrations_module.pools_coll = object()
+    integrations_module.mongodb_enabled = True
+    integrations_module.publish_to_rabbitmq = lambda *args, **kwargs: None
+    integrations_module.rabbitmq_manager = types.SimpleNamespace(connection=None)
+    integrations_module.__path__ = []
+
+    rabbitmq_module = types.ModuleType("integrations.rabbitmq")
+    rabbitmq_module.start_heartbeat_thread = lambda: None
+
+    analytics_package = types.ModuleType("analytics")
+    analytics_package.__path__ = []
+
+    prev_hash_divergence_module = types.ModuleType("analytics.prev_hash_divergence")
+    prev_hash_divergence_module.analyze_prev_hash_divergence = lambda templates, logger: None
+
+    invalid_coinbase_module = types.ModuleType("analytics.invalid_coinbase_no_merkle")
+    invalid_coinbase_module.analyze_invalid_coinbase_without_merkle = lambda templates, height, logger: None
+
+    pool_identification_module = types.ModuleType("analytics.pool_identification")
+    pool_identification_module.analyze_pool_identification = lambda *args, **kwargs: {}
+    pool_identification_module.identify_pool_from_data = lambda *args, **kwargs: {}
+    pool_identification_module.load_pools = lambda *args, **kwargs: None
+
+    bitcoin_utils_module = types.ModuleType("bitcoin_utils")
+    bitcoin_utils_module.extract_coinbase_data = lambda block: ("", [])
+
+    zmq_module = types.ModuleType("zmq")
+    zmq_module.Context = lambda: types.SimpleNamespace(socket=lambda *args, **kwargs: types.SimpleNamespace(
+        setsockopt=lambda *a, **k: None,
+        connect=lambda *a, **k: None,
+        recv_multipart=lambda: [],
+    ))
+    zmq_module.SUB = 1
+    zmq_module.SUBSCRIBE = 2
+
+    sys.modules["bitcoinrpc"] = bitcoinrpc_module
+    sys.modules["bitcoinrpc.authproxy"] = authproxy_module
+    sys.modules["integrations"] = integrations_module
+    sys.modules["integrations.rabbitmq"] = rabbitmq_module
+    sys.modules["analytics"] = analytics_package
+    sys.modules["analytics.prev_hash_divergence"] = prev_hash_divergence_module
+    sys.modules["analytics.invalid_coinbase_no_merkle"] = invalid_coinbase_module
+    sys.modules["analytics.pool_identification"] = pool_identification_module
+    sys.modules["bitcoin_utils"] = bitcoin_utils_module
+    sys.modules["zmq"] = zmq_module
+
+    sys.modules.pop("main", None)
+    return importlib.import_module("main"), fake_db
+
+
+class BTCTemplateFilteringTests(unittest.TestCase):
+    def test_run_block_analyses_queries_btc_only_templates(self):
+        main, fake_db = import_main_module()
+
+        main.run_block_analyses(123)
+
+        self.assertEqual(
+            fake_db.mining_notify.queries,
+            [{"height": 123, "chain_family": {"$exists": False}}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -6,6 +6,6 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY main.py .
+COPY main.py chain_detection.py ./
 
 CMD ["/usr/local/bin/python", "main.py"]

--- a/collector/chain_detection.py
+++ b/collector/chain_detection.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import requests
+
+
+def reverse_prev_hash(prev_hash: str) -> str:
+    return bytes.fromhex(prev_hash)[::-1].hex()
+
+
+@dataclass
+class TipState:
+    current_height: Optional[int]
+    last_update_monotonic: Optional[float]
+    stale_after_seconds: int
+
+    def is_usable(self, now: float) -> bool:
+        if self.current_height is None or self.last_update_monotonic is None:
+            return False
+        return (now - self.last_update_monotonic) <= self.stale_after_seconds
+
+
+class BCHConfirmationCache:
+    def __init__(self) -> None:
+        self._prev_hash: Optional[str] = None
+        self._is_bch: Optional[bool] = None
+
+    def lookup(self, prev_hash: str) -> Optional[bool]:
+        if prev_hash != self._prev_hash:
+            return None
+        return self._is_bch
+
+    def store(self, prev_hash: str, is_bch: bool) -> None:
+        self._prev_hash = prev_hash
+        self._is_bch = is_bch
+
+
+class BCHConfirmer:
+    def __init__(self, api_base_url: str, timeout_seconds: float, cache: BCHConfirmationCache) -> None:
+        self.api_base_url = api_base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self.cache = cache
+
+    def confirm_bch(self, prev_hash: str) -> bool:
+        cached = self.cache.lookup(prev_hash)
+        if cached is not None:
+            return cached
+
+        try:
+            response = requests.get(
+                f"{self.api_base_url}/{reverse_prev_hash(prev_hash)}",
+                timeout=self.timeout_seconds,
+            )
+        except requests.RequestException:
+            return False
+
+        is_bch = self._response_indicates_bch(response)
+        if is_bch:
+            self.cache.store(prev_hash, True)
+        return is_bch
+
+    @staticmethod
+    def _response_indicates_bch(response: requests.Response) -> bool:
+        if not response.ok:
+            return False
+
+        try:
+            payload = response.json()
+        except ValueError:
+            return False
+
+        if not isinstance(payload, dict):
+            return False
+
+        return bool(payload.get("data"))
+
+
+class ChainClassifier:
+    def __init__(
+        self,
+        tip_state: TipState,
+        divergence_threshold: int,
+        confirmer: BCHConfirmer,
+        monotonic_now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.tip_state = tip_state
+        self.divergence_threshold = divergence_threshold
+        self.confirmer = confirmer
+        self.monotonic_now = monotonic_now
+
+    def classify(self, height: int, prev_hash: str) -> Optional[str]:
+        now = self.monotonic_now()
+        if not self.tip_state.is_usable(now):
+            return None
+        if abs(height - self.tip_state.current_height) <= self.divergence_threshold:
+            return None
+        if self.confirmer.confirm_bch(prev_hash):
+            return "bch"
+        return "unknown"

--- a/collector/main.py
+++ b/collector/main.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import threading
 import socket
 import sys
 import time
@@ -9,12 +10,159 @@ from datetime import datetime
 from urllib.parse import urlparse
 import select
 
-import pika
-from pymongo import MongoClient
-from pycoin.symbols.btc import network
-import socks
+try:
+    import pika
+except ImportError:  # pragma: no cover - exercised in lightweight test envs
+    pika = None
+
+try:
+    from pymongo import MongoClient
+except ImportError:  # pragma: no cover - exercised in lightweight test envs
+    MongoClient = None
+
+try:
+    from pycoin.symbols.btc import network
+except ImportError:  # pragma: no cover - exercised in lightweight test envs
+    network = None
+
+try:
+    import socks
+except ImportError:  # pragma: no cover - exercised in lightweight test envs
+    socks = None
+
+try:
+    import zmq
+except ImportError:  # pragma: no cover - exercised in lightweight test envs
+    zmq = None
+
+try:
+    from collector.chain_detection import (
+        BCHConfirmationCache,
+        BCHConfirmer,
+        ChainClassifier,
+        TipState,
+    )
+except ImportError:  # pragma: no cover - allows `python3 collector/main.py`
+    from chain_detection import (  # type: ignore
+        BCHConfirmationCache,
+        BCHConfirmer,
+        ChainClassifier,
+        TipState,
+    )
 
 LOG = logging.getLogger()
+
+tip_state = TipState(
+    current_height=None,
+    last_update_monotonic=None,
+    stale_after_seconds=1800,
+)
+bch_confirmer = BCHConfirmer(
+    "https://api.blockchair.com/bitcoin-cash/raw/block",
+    3.0,
+    BCHConfirmationCache(),
+)
+chain_classifier = ChainClassifier(
+    tip_state=tip_state,
+    divergence_threshold=5,
+    confirmer=bch_confirmer,
+)
+tip_state_lock = threading.Lock()
+
+
+def require_dependency(module, name):
+    if module is None:
+        raise RuntimeError(f"Missing optional dependency '{name}'")
+    return module
+
+
+def configure_chain_detection(args):
+    tip_state.stale_after_seconds = args.btc_tip_stale_seconds
+    chain_classifier.divergence_threshold = args.btc_chain_divergence_threshold
+    bch_confirmer.api_base_url = args.bch_confirmation_url.rstrip("/")
+    bch_confirmer.timeout_seconds = args.bch_confirmation_timeout
+
+
+def update_tip_state(height):
+    with tip_state_lock:
+        tip_state.current_height = height
+        tip_state.last_update_monotonic = time.monotonic()
+
+
+def fetch_local_btc_tip_height(args):
+    try:
+        from bitcoinrpc.authproxy import AuthServiceProxy
+    except ImportError as exc:  # pragma: no cover - depends on local env
+        raise RuntimeError("Missing optional dependency 'python-bitcoinrpc'") from exc
+
+    rpc_url = (
+        f"http://{args.bitcoin_rpc_user}:{args.bitcoin_rpc_password}"
+        f"@{args.bitcoin_rpc_host}:{args.bitcoin_rpc_port}"
+    )
+    conn = AuthServiceProxy(rpc_url, timeout=args.bitcoin_rpc_timeout)
+    return int(conn.getblockcount())
+
+
+def initialize_tip_state(args):
+    height = fetch_local_btc_tip_height(args)
+    update_tip_state(height)
+    LOG.info("Initialized BTC tip state at height %s", height)
+
+
+def listen_for_btc_tip_updates(args):
+    require_dependency(zmq, "pyzmq")
+    context = zmq.Context.instance()
+    while True:
+        socket_obj = None
+        try:
+            socket_obj = context.socket(zmq.SUB)
+            socket_obj.setsockopt(zmq.SUBSCRIBE, b"rawblock")
+            socket_obj.setsockopt(zmq.SUBSCRIBE, b"hashblock")
+            socket_obj.connect(args.bitcoin_zmq_block)
+            LOG.info("BTC tip listener connected to %s", args.bitcoin_zmq_block)
+            while True:
+                parts = socket_obj.recv_multipart()
+                if len(parts) < 2:
+                    continue
+                height = fetch_local_btc_tip_height(args)
+                update_tip_state(height)
+                LOG.debug("Updated BTC tip state to height %s", height)
+        except Exception as exc:
+            LOG.warning("BTC tip listener error: %s", exc)
+            time.sleep(5)
+        finally:
+            if socket_obj is not None:
+                socket_obj.close()
+
+
+def start_tip_listener(args):
+    if zmq is None:
+        LOG.warning("BTC tip listener unavailable: missing optional dependency 'pyzmq'")
+        return None
+    listener = threading.Thread(
+        target=listen_for_btc_tip_updates,
+        args=(args,),
+        name="btc-tip-listener",
+        daemon=True,
+    )
+    listener.start()
+    return listener
+
+
+def classify_notification_chain(height: int, prev_hash: str) -> str | None:
+    try:
+        if height <= 0 or not prev_hash:
+            return None
+        with tip_state_lock:
+            return chain_classifier.classify(height=height, prev_hash=prev_hash)
+    except Exception as exc:
+        LOG.warning(
+            "Chain classification skipped for height=%s prev_hash=%s: %s",
+            height,
+            prev_hash[:16],
+            exc,
+        )
+        return None
 
 class Watcher:
     def __init__(self, url, userpass, pool_name, rabbitmq_host, rabbitmq_port, rabbitmq_username, rabbitmq_password, rabbitmq_exchange, db_url, db_name, db_username, db_password, use_proxy=False, proxy_host=None, proxy_port=None, enable_stratum_client=False, stratum_client_port=None, rabbitmq_enabled=True, db_enabled=True):
@@ -67,6 +215,7 @@ class Watcher:
     def init_socket(self):
         LOG.info("Initializing socket")
         if self.use_proxy:
+            require_dependency(socks, "PySocks")
             LOG.info(f"Using proxy: {self.proxy_host}:{self.proxy_port}")
             self.sock = socks.socksocket()
             self.sock.set_proxy(socks.SOCKS5, self.proxy_host, self.proxy_port)
@@ -150,6 +299,7 @@ class Watcher:
             self.pending_notifications.append((msg, ts))
 
     def connect_to_rabbitmq(self):
+        require_dependency(pika, "pika")
         for attempt in range(self.max_retries):
             try:
                 credentials = pika.PlainCredentials(self.rabbitmq_username, self.rabbitmq_password)
@@ -335,10 +485,12 @@ def create_notification_document(data, pool_name, extranonce1, extranonce2_lengt
     coinbase = None
     height = 0
     try:
+        if network is None:
+            raise RuntimeError("Missing optional dependency 'pycoin'")
         coinbase = network.Tx.from_hex(coinbase1 + extranonce1 + "00"*extranonce2_length + coinbase2)
         height = int.from_bytes(coinbase.txs_in[0].script[1:4], byteorder='little')
     except Exception as e:
-        print(e)
+        LOG.debug("Failed to derive template height from coinbase: %s", e)
     document = {
         "_id": notification_id,
         "timestamp": timestamp,
@@ -356,9 +508,13 @@ def create_notification_document(data, pool_name, extranonce1, extranonce2_lengt
         "extranonce1": extranonce1,
         "extranonce2_length": extranonce2_length
     }
+    chain_family = classify_notification_chain(height, data["params"][1])
+    if chain_family is not None:
+        document["chain_family"] = chain_family
     return document
 
 def insert_notification(document, db_url, db_name, db_username, db_password):
+    require_dependency(MongoClient, "pymongo")
     LOG.debug(f"Attempting to insert document into MongoDB: {document}")
     host = db_url
     for prefix in ("mongodb+srv://", "mongodb://"):
@@ -433,10 +589,66 @@ def main():
     parser.add_argument(
         "--stratum-client-port", type=int, default=3333, help="Port to listen for Stratum client connections (default: 3333)"
     )
+    parser.add_argument(
+        "--bitcoin-zmq-block",
+        default="tcp://bitcoin-node:28332",
+        help="Bitcoin node ZMQ block endpoint (default: tcp://bitcoin-node:28332)",
+    )
+    parser.add_argument(
+        "--bitcoin-rpc-user",
+        default="user",
+        help="Bitcoin RPC username (default: user)",
+    )
+    parser.add_argument(
+        "--bitcoin-rpc-password",
+        default="password",
+        help="Bitcoin RPC password",
+    )
+    parser.add_argument(
+        "--bitcoin-rpc-host",
+        default="localhost",
+        help="Bitcoin RPC host (default: localhost)",
+    )
+    parser.add_argument(
+        "--bitcoin-rpc-port",
+        default="8332",
+        help="Bitcoin RPC port (default: 8332)",
+    )
+    parser.add_argument(
+        "--bitcoin-rpc-timeout",
+        type=float,
+        default=3.0,
+        help="Bitcoin RPC timeout in seconds (default: 3.0)",
+    )
+    parser.add_argument(
+        "--btc-chain-divergence-threshold",
+        type=int,
+        default=5,
+        help="Height divergence threshold before non-BTC confirmation (default: 5)",
+    )
+    parser.add_argument(
+        "--btc-tip-stale-seconds",
+        type=int,
+        default=1800,
+        help="Seconds before local BTC tip data is considered stale (default: 1800)",
+    )
+    parser.add_argument(
+        "--bch-confirmation-url",
+        default="https://api.blockchair.com/bitcoin-cash/raw/block",
+        help="BCH block confirmation API base URL",
+    )
+    parser.add_argument(
+        "--bch-confirmation-timeout",
+        type=float,
+        default=3.0,
+        help="BCH confirmation timeout in seconds (default: 3.0)",
+    )
     args = parser.parse_args()
 
     if args.pool_name is None:
         args.pool_name = urlparse(args.url).hostname
+
+    configure_chain_detection(args)
 
     rabbitmq_enabled = args.rabbitmq_username is not None and args.rabbitmq_password is not None
     db_enabled = args.db_username is not None and args.db_password is not None
@@ -452,6 +664,12 @@ def main():
     )
     LOG.info(f"Logging level set to {args.log_level.upper()}")
     LOG.info(f"Pool name: {args.pool_name}")
+    try:
+        initialize_tip_state(args)
+    except Exception as exc:
+        LOG.warning("Initial BTC tip setup failed; classification disabled until tip data is available: %s", exc)
+    start_tip_listener(args)
+
     backends = []
     if rabbitmq_enabled:
         backends.append("RabbitMQ")

--- a/collector/main.py
+++ b/collector/main.py
@@ -68,6 +68,10 @@ chain_classifier = ChainClassifier(
     confirmer=bch_confirmer,
 )
 tip_state_lock = threading.Lock()
+mongo_client_lock = threading.Lock()
+cached_mongo_client = None
+cached_mongo_collection = None
+cached_mongo_config = None
 
 
 def require_dependency(module, name):
@@ -89,6 +93,58 @@ def update_tip_state(height):
         tip_state.last_update_monotonic = time.monotonic()
 
 
+def close_rpc_connection(conn):
+    raw_conn = getattr(conn, "_AuthServiceProxy__conn", None)
+    raw_close = getattr(raw_conn, "close", None)
+    if callable(raw_close):
+        raw_close()
+        return
+
+    close_method = getattr(conn, "close", None)
+    if callable(close_method):
+        close_method()
+
+
+def normalize_mongo_host(db_url):
+    host = db_url
+    for prefix in ("mongodb+srv://", "mongodb://"):
+        if host.startswith(prefix):
+            return host[len(prefix):]
+    return host
+
+
+def get_mongo_collection(db_url, db_name, db_username, db_password):
+    require_dependency(MongoClient, "pymongo")
+    global cached_mongo_client, cached_mongo_collection, cached_mongo_config
+
+    config = (db_url, db_name, db_username, db_password)
+    with mongo_client_lock:
+        if cached_mongo_collection is not None and cached_mongo_config == config:
+            return cached_mongo_collection
+
+        if cached_mongo_client is not None:
+            cached_mongo_client.close()
+
+        host = normalize_mongo_host(db_url)
+        cached_mongo_client = MongoClient(
+            f"mongodb://{db_username}:{db_password}@{host}"
+        )
+        cached_mongo_collection = cached_mongo_client[db_name]["mining_notify"]
+        cached_mongo_config = config
+        return cached_mongo_collection
+
+
+def close_cached_mongo_client():
+    global cached_mongo_client, cached_mongo_collection, cached_mongo_config
+
+    with mongo_client_lock:
+        if cached_mongo_client is not None:
+            cached_mongo_client.close()
+        cached_mongo_client = None
+        cached_mongo_collection = None
+        cached_mongo_config = None
+
+
 def fetch_local_btc_tip_height(args):
     try:
         from bitcoinrpc.authproxy import AuthServiceProxy
@@ -100,7 +156,10 @@ def fetch_local_btc_tip_height(args):
         f"@{args.bitcoin_rpc_host}:{args.bitcoin_rpc_port}"
     )
     conn = AuthServiceProxy(rpc_url, timeout=args.bitcoin_rpc_timeout)
-    return int(conn.getblockcount())
+    try:
+        return int(conn.getblockcount())
+    finally:
+        close_rpc_connection(conn)
 
 
 def initialize_tip_state(args):
@@ -514,20 +573,10 @@ def create_notification_document(data, pool_name, extranonce1, extranonce2_lengt
     return document
 
 def insert_notification(document, db_url, db_name, db_username, db_password):
-    require_dependency(MongoClient, "pymongo")
     LOG.debug(f"Attempting to insert document into MongoDB: {document}")
-    host = db_url
-    for prefix in ("mongodb+srv://", "mongodb://"):
-        if host.startswith(prefix):
-            host = host[len(prefix):]
-            break
-    client = MongoClient(f"mongodb://{db_username}:{db_password}@{host}")
-    db = client[db_name]
-    collection = db["mining_notify"]
+    collection = get_mongo_collection(db_url, db_name, db_username, db_password)
     result = collection.insert_one(document)
     LOG.info(f"Inserted document with id {result.inserted_id}")
-    client.close()
-    LOG.debug("MongoDB connection closed")
 
 def main():
     parser = argparse.ArgumentParser(
@@ -711,6 +760,8 @@ def main():
                     w.close()
                     if rabbitmq_enabled and w.connection:
                         w.connection.close()
+                    if db_enabled:
+                        close_cached_mongo_client()
                 except Exception:
                     pass
                 try:
@@ -738,6 +789,8 @@ def main():
                 w.close()
                 if rabbitmq_enabled and w.connection:
                     w.connection.close()
+                if db_enabled:
+                    close_cached_mongo_client()
 
 if __name__ == "__main__":
     main()

--- a/collector/requirements.txt
+++ b/collector/requirements.txt
@@ -1,5 +1,8 @@
 pika==1.3.2
 pycoin==0.92.20230326
 pymongo==4.7.2
+pyzmq==27.1.0
 PySocks==1.7.1
+python-bitcoinrpc==1.0
+requests==2.31.0
 setuptools==69.5.1

--- a/collector/tests/test_chain_detection.py
+++ b/collector/tests/test_chain_detection.py
@@ -1,0 +1,339 @@
+import unittest
+import types
+import sys
+from argparse import Namespace
+from unittest.mock import Mock, patch
+
+import requests
+
+from collector.chain_detection import (
+    BCHConfirmationCache,
+    BCHConfirmer,
+    ChainClassifier,
+    TipState,
+    reverse_prev_hash,
+)
+
+sys.modules.setdefault("pika", types.SimpleNamespace())
+sys.modules.setdefault("socks", types.SimpleNamespace())
+sys.modules.setdefault("pymongo", types.SimpleNamespace(MongoClient=Mock()))
+fake_network = types.SimpleNamespace(Tx=types.SimpleNamespace(from_hex=Mock()))
+sys.modules.setdefault("pycoin", types.SimpleNamespace())
+sys.modules.setdefault("pycoin.symbols", types.SimpleNamespace())
+sys.modules.setdefault("pycoin.symbols.btc", types.SimpleNamespace(network=fake_network))
+
+import collector.main as collector_main
+from collector.main import create_notification_document
+
+
+class ChainDetectionTests(unittest.TestCase):
+    def test_reverse_prev_hash_converts_stratum_little_endian_to_rpc_big_endian(self):
+        self.assertEqual(
+            reverse_prev_hash(
+                "40d9f2088de1ca410fcddd20e0f713e225e4176800fc282d0000000000000000"
+            ),
+            "00000000000000002d28fc006817e425e213f7e020ddcd0f41cae18d08f2d940",
+        )
+
+    def test_classifier_skips_detection_when_tip_state_is_unavailable(self):
+        classifier = ChainClassifier(
+            tip_state=TipState(
+                current_height=None,
+                last_update_monotonic=None,
+                stale_after_seconds=60,
+            ),
+            divergence_threshold=5,
+            confirmer=Mock(spec=BCHConfirmer),
+            monotonic_now=lambda: 120.0,
+        )
+
+        self.assertIsNone(classifier.classify(height=945964, prev_hash="00" * 32))
+        classifier.confirmer.confirm_bch.assert_not_called()
+
+    def test_classifier_skips_detection_inside_height_window(self):
+        classifier = ChainClassifier(
+            tip_state=TipState(
+                current_height=945964,
+                last_update_monotonic=100.0,
+                stale_after_seconds=60,
+            ),
+            divergence_threshold=5,
+            confirmer=Mock(spec=BCHConfirmer),
+            monotonic_now=lambda: 120.0,
+        )
+
+        self.assertIsNone(classifier.classify(height=945960, prev_hash="00" * 32))
+        classifier.confirmer.confirm_bch.assert_not_called()
+
+    def test_classifier_marks_confirmed_bch_when_height_diverges_and_api_confirms(self):
+        confirmer = Mock(spec=BCHConfirmer)
+        confirmer.confirm_bch.return_value = True
+        classifier = ChainClassifier(
+            tip_state=TipState(
+                current_height=945964,
+                last_update_monotonic=100.0,
+                stale_after_seconds=60,
+            ),
+            divergence_threshold=5,
+            confirmer=confirmer,
+            monotonic_now=lambda: 120.0,
+        )
+
+        result = classifier.classify(
+            height=945900,
+            prev_hash="40d9f2088de1ca410fcddd20e0f713e225e4176800fc282d0000000000000000",
+        )
+
+        self.assertEqual(result, "bch")
+        confirmer.confirm_bch.assert_called_once_with(
+            "40d9f2088de1ca410fcddd20e0f713e225e4176800fc282d0000000000000000"
+        )
+
+    def test_classifier_marks_divergent_non_bch_as_unknown(self):
+        confirmer = Mock(spec=BCHConfirmer)
+        confirmer.confirm_bch.return_value = False
+        classifier = ChainClassifier(
+            tip_state=TipState(
+                current_height=945964,
+                last_update_monotonic=100.0,
+                stale_after_seconds=60,
+            ),
+            divergence_threshold=5,
+            confirmer=confirmer,
+            monotonic_now=lambda: 120.0,
+        )
+
+        result = classifier.classify(
+            height=6560463,
+            prev_hash="58dcd5b64e522d28de60983366c6788b1a74584a69845173d6faa16b2718c906",
+        )
+
+        self.assertEqual(result, "unknown")
+        confirmer.confirm_bch.assert_called_once_with(
+            "58dcd5b64e522d28de60983366c6788b1a74584a69845173d6faa16b2718c906"
+        )
+
+    def test_one_entry_cache_reuses_last_confirmed_prev_hash(self):
+        cache = BCHConfirmationCache()
+        confirmer = BCHConfirmer("https://example.invalid", timeout_seconds=1.5, cache=cache)
+        prev_hash = "40d9f2088de1ca410fcddd20e0f713e225e4176800fc282d0000000000000000"
+
+        response = Mock()
+        response.ok = True
+        response.json.return_value = {"data": {"chain": "bch"}}
+
+        with patch("collector.chain_detection.requests.get", return_value=response) as get_mock:
+            self.assertTrue(confirmer.confirm_bch(prev_hash))
+            self.assertTrue(confirmer.confirm_bch(prev_hash))
+            self.assertEqual(get_mock.call_count, 1)
+            self.assertEqual(cache.lookup(prev_hash), True)
+            self.assertIsNone(cache.lookup("def"))
+
+    def test_confirm_bch_returns_false_when_request_raises(self):
+        cache = BCHConfirmationCache()
+        confirmer = BCHConfirmer("https://example.invalid", timeout_seconds=1.5, cache=cache)
+
+        with patch(
+            "collector.chain_detection.requests.get",
+            side_effect=requests.RequestException("boom"),
+        ):
+            self.assertFalse(
+                confirmer.confirm_bch(
+                    "40d9f2088de1ca410fcddd20e0f713e225e4176800fc282d0000000000000000"
+                )
+            )
+
+    def test_confirm_bch_returns_false_when_response_is_not_json(self):
+        cache = BCHConfirmationCache()
+        confirmer = BCHConfirmer("https://example.invalid", timeout_seconds=1.5, cache=cache)
+
+        response = Mock()
+        response.ok = True
+        response.json.side_effect = ValueError("not json")
+
+        with patch("collector.chain_detection.requests.get", return_value=response):
+            self.assertFalse(
+                confirmer.confirm_bch(
+                    "40d9f2088de1ca410fcddd20e0f713e225e4176800fc282d0000000000000000"
+                )
+            )
+
+    def test_confirm_bch_returns_false_when_data_payload_is_null(self):
+        cache = BCHConfirmationCache()
+        confirmer = BCHConfirmer("https://example.invalid", timeout_seconds=1.5, cache=cache)
+
+        response = Mock()
+        response.ok = True
+        response.json.return_value = {"data": None}
+
+        with patch("collector.chain_detection.requests.get", return_value=response):
+            self.assertFalse(
+                confirmer.confirm_bch(
+                    "40d9f2088de1ca410fcddd20e0f713e225e4176800fc282d0000000000000000"
+                )
+            )
+
+
+class NotificationDocumentTests(unittest.TestCase):
+    @patch("collector.main.classify_notification_chain")
+    @patch("collector.main.network.Tx.from_hex")
+    def test_create_notification_document_calls_classifier_with_parsed_height_and_prev_hash(
+        self, from_hex_mock, classify_mock
+    ):
+        classify_mock.return_value = None
+        tx = Mock()
+        tx.txs_in = [Mock(script=b"\x03\x34\x12\x00")]
+        from_hex_mock.return_value = tx
+        data = {
+            "params": [
+                "job1",
+                "22" * 32,
+                "coinbase1",
+                "coinbase2",
+                [],
+                "20000000",
+                "18014bb3",
+                "69d72a43",
+                True,
+            ]
+        }
+
+        doc = create_notification_document(data, "Braiins", "abcd", 2, "deadbeef")
+
+        self.assertEqual(doc["height"], 0x1234)
+        classify_mock.assert_called_once_with(0x1234, "22" * 32)
+
+    @patch("collector.main.classify_notification_chain")
+    def test_create_notification_document_omits_chain_family_for_btc_default(
+        self, classify_mock
+    ):
+        classify_mock.return_value = None
+        data = {
+            "params": [
+                "job1",
+                "00" * 32,
+                "coinbase1",
+                "coinbase2",
+                [],
+                "20000000",
+                "18014bb3",
+                "69d72a43",
+                True,
+            ]
+        }
+
+        doc = create_notification_document(data, "Braiins", "", 6, "deadbeef")
+
+        self.assertNotIn("chain_family", doc)
+
+    @patch("collector.main.classify_notification_chain")
+    @patch("collector.main.network.Tx.from_hex", side_effect=ValueError("bad coinbase"))
+    def test_create_notification_document_omits_chain_family_when_height_parse_fails(
+        self, from_hex_mock, classify_mock
+    ):
+        classify_mock.return_value = None
+        data = {
+            "params": [
+                "job1",
+                "33" * 32,
+                "coinbase1",
+                "coinbase2",
+                [],
+                "20000000",
+                "18014bb3",
+                "69d72a43",
+                True,
+            ]
+        }
+
+        doc = create_notification_document(data, "Braiins", "", 6, "deadbeef")
+
+        self.assertEqual(doc["height"], 0)
+        self.assertNotIn("chain_family", doc)
+        classify_mock.assert_called_once_with(0, "33" * 32)
+        from_hex_mock.assert_called_once()
+
+    @patch("collector.main.classify_notification_chain")
+    def test_create_notification_document_sets_chain_family_for_confirmed_bch(
+        self, classify_mock
+    ):
+        classify_mock.return_value = "bch"
+        data = {
+            "params": [
+                "job1",
+                "11" * 32,
+                "coinbase1",
+                "coinbase2",
+                [],
+                "20000000",
+                "18014bb3",
+                "69d72a43",
+                True,
+            ]
+        }
+
+        doc = create_notification_document(data, "Braiins", "", 6, "deadbeef")
+
+        self.assertEqual(doc["chain_family"], "bch")
+
+    @patch("collector.main.classify_notification_chain")
+    def test_create_notification_document_sets_chain_family_for_unknown_non_btc(
+        self, classify_mock
+    ):
+        classify_mock.return_value = "unknown"
+        data = {
+            "params": [
+                "job1",
+                "58dcd5b64e522d28de60983366c6788b1a74584a69845173d6faa16b2718c906",
+                "coinbase1",
+                "coinbase2",
+                [],
+                "20000000",
+                "18014bb3",
+                "69d72a43",
+                True,
+            ]
+        }
+
+        doc = create_notification_document(data, "Headframe", "", 6, "deadbeef")
+
+        self.assertEqual(doc["chain_family"], "unknown")
+
+
+class RuntimeConfigTests(unittest.TestCase):
+    def test_configure_chain_detection_applies_cli_bitcoin_config(self):
+        original = {
+            "tip_state_stale_after": collector_main.tip_state.stale_after_seconds,
+            "classifier_threshold": collector_main.chain_classifier.divergence_threshold,
+            "confirmer_url": collector_main.bch_confirmer.api_base_url,
+            "confirmer_timeout": collector_main.bch_confirmer.timeout_seconds,
+        }
+        try:
+            collector_main.configure_chain_detection(
+                Namespace(
+                    bitcoin_zmq_block="tcp://btc-node:29000",
+                    bitcoin_rpc_user="rpcuser",
+                    bitcoin_rpc_password="rpcpass",
+                    bitcoin_rpc_host="btc-node",
+                    bitcoin_rpc_port="18443",
+                    bitcoin_rpc_timeout=7.5,
+                    btc_chain_divergence_threshold=12,
+                    btc_tip_stale_seconds=90,
+                    bch_confirmation_url="https://example.invalid/bch",
+                    bch_confirmation_timeout=4.25,
+                )
+            )
+
+            self.assertEqual(collector_main.tip_state.stale_after_seconds, 90)
+            self.assertEqual(collector_main.chain_classifier.divergence_threshold, 12)
+            self.assertEqual(collector_main.bch_confirmer.api_base_url, "https://example.invalid/bch")
+            self.assertEqual(collector_main.bch_confirmer.timeout_seconds, 4.25)
+        finally:
+            collector_main.tip_state.stale_after_seconds = original["tip_state_stale_after"]
+            collector_main.chain_classifier.divergence_threshold = original["classifier_threshold"]
+            collector_main.bch_confirmer.api_base_url = original["confirmer_url"]
+            collector_main.bch_confirmer.timeout_seconds = original["confirmer_timeout"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/collector/tests/test_chain_detection.py
+++ b/collector/tests/test_chain_detection.py
@@ -335,5 +335,117 @@ class RuntimeConfigTests(unittest.TestCase):
             collector_main.bch_confirmer.timeout_seconds = original["confirmer_timeout"]
 
 
+class TipListenerTests(unittest.TestCase):
+    def test_fetch_local_btc_tip_height_closes_underlying_rpc_connection(self):
+        args = Namespace(
+            bitcoin_rpc_user="rpcuser",
+            bitcoin_rpc_password="rpcpass",
+            bitcoin_rpc_host="btc-node",
+            bitcoin_rpc_port="18443",
+            bitcoin_rpc_timeout=7.5,
+        )
+        http_conn = Mock()
+        proxy = types.SimpleNamespace(
+            getblockcount=Mock(return_value=101),
+            _AuthServiceProxy__conn=http_conn,
+        )
+        auth_proxy_cls = Mock(return_value=proxy)
+
+        with patch.dict(
+            sys.modules,
+            {
+                "bitcoinrpc": types.SimpleNamespace(),
+                "bitcoinrpc.authproxy": types.SimpleNamespace(
+                    AuthServiceProxy=auth_proxy_cls
+                ),
+            },
+        ):
+            height = collector_main.fetch_local_btc_tip_height(args)
+
+        self.assertEqual(height, 101)
+        auth_proxy_cls.assert_called_once_with(
+            "http://rpcuser:rpcpass@btc-node:18443",
+            timeout=7.5,
+        )
+        proxy.getblockcount.assert_called_once_with()
+        http_conn.close.assert_called_once_with()
+
+    def test_close_rpc_connection_uses_underlying_http_connection_not_rpc_method(self):
+        http_conn = Mock()
+
+        class FakeProxy:
+            def __init__(self):
+                self._AuthServiceProxy__conn = http_conn
+
+            def close(self):
+                raise AssertionError("RPC close() method should not be invoked")
+
+        collector_main.close_rpc_connection(FakeProxy())
+
+        http_conn.close.assert_called_once_with()
+
+
+class MongoClientReuseTests(unittest.TestCase):
+    def setUp(self):
+        collector_main.cached_mongo_client = None
+        collector_main.cached_mongo_collection = None
+        collector_main.cached_mongo_config = None
+
+    def tearDown(self):
+        collector_main.cached_mongo_client = None
+        collector_main.cached_mongo_collection = None
+        collector_main.cached_mongo_config = None
+
+    @patch("collector.main.MongoClient")
+    def test_get_mongo_collection_reuses_cached_client_for_same_config(
+        self, mongo_client_cls
+    ):
+        client = Mock()
+        database = Mock()
+        collection = Mock()
+        mongo_client_cls.return_value = client
+        client.__getitem__ = Mock(return_value=database)
+        database.__getitem__ = Mock(return_value=collection)
+
+        first = collector_main.get_mongo_collection(
+            "mongodb://mongo:27017",
+            "stratum-logger",
+            "user",
+            "pass",
+        )
+        second = collector_main.get_mongo_collection(
+            "mongodb://mongo:27017",
+            "stratum-logger",
+            "user",
+            "pass",
+        )
+
+        self.assertIs(first, collection)
+        self.assertIs(second, collection)
+        mongo_client_cls.assert_called_once_with("mongodb://user:pass@mongo:27017")
+
+    @patch("collector.main.MongoClient")
+    def test_close_cached_mongo_client_closes_shared_client(self, mongo_client_cls):
+        client = Mock()
+        database = Mock()
+        collection = Mock()
+        mongo_client_cls.return_value = client
+        client.__getitem__ = Mock(return_value=database)
+        database.__getitem__ = Mock(return_value=collection)
+
+        collector_main.get_mongo_collection(
+            "mongodb://mongo:27017",
+            "stratum-logger",
+            "user",
+            "pass",
+        )
+        collector_main.close_cached_mongo_client()
+
+        client.close.assert_called_once_with()
+        self.assertIsNone(collector_main.cached_mongo_client)
+        self.assertIsNone(collector_main.cached_mongo_collection)
+        self.assertIsNone(collector_main.cached_mongo_config)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/app/api/analysis-data/route.ts
+++ b/web/app/api/analysis-data/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getMiningNotifyByHeight } from "@/lib/db/mining-notify";
 import { getBlockByHeight } from "@/lib/db/blocks";
 import { prisma } from "@/lib/db/prisma";
-import { filterBlacklistedItems } from "@/lib/poolBlacklist";
 
 interface InterestingBlockItem {
   height: number;
@@ -21,6 +19,8 @@ import {
   computeFirstTransaction, 
   computeCoinbaseOutputs 
 } from "@/utils/bitcoinUtils";
+
+const enableHistoricalData = (process.env.ENABLE_HISTORICAL_DATA ?? "true").toLowerCase() === "true";
 
 /**
  * API endpoint that returns Bitcoin mining data with all computed values for analysis
@@ -81,11 +81,7 @@ export async function GET(request: NextRequest) {
         limit: 200
       }) as unknown as MongoCursorResult<InterestingBlockItem>;
       const items: InterestingBlockItem[] = raw?.cursor?.firstBatch || [];
-      const filtered = filterBlacklistedItems(
-        items,
-        item => (item.mining_pool?.name as string | undefined)
-      );
-      return NextResponse.json({ items: filtered });
+      return NextResponse.json({ items });
     } catch (e) {
       console.error('Error fetching interesting blocks:', e);
       return NextResponse.json({ items: [] });
@@ -107,14 +103,17 @@ export async function GET(request: NextRequest) {
     // Process each height in parallel
     const results = await Promise.all(heights.map(async (height) => {
       // Fetch mining notifications for the requested height
-      const miningNotifications = await getMiningNotifyByHeight(height);
+      const miningNotifications = enableHistoricalData
+        ? await prisma.miningNotify.findMany({
+            where: { height },
+          })
+        : [];
       
       // Fetch block details for the requested height and previous height
       const currentBlock = await getBlockByHeight(height);
       const previousBlock = await getBlockByHeight(height - 1);
       
-      const filteredNotifications = filterBlacklistedItems(miningNotifications, n => n.pool_name);
-      const processedData = filteredNotifications.map(notification => {
+      const processedData = miningNotifications.map(notification => {
         let coinbaseRaw = '';
         let coinbaseScriptASCII = '';
         let coinbaseOutputValue = 0;
@@ -147,6 +146,7 @@ export async function GET(request: NextRequest) {
           // Original fields from the notification (excluding coinbase1 and coinbase2)
           id: notification.id,
           pool_name: notification.pool_name,
+          chain_family: notification.chain_family ?? undefined,
           timestamp: notification.timestamp,
           height: notification.height,
           prev_hash: prevHash, // Use only the reversed (big-endian) format

--- a/web/app/api/block-pool-first-seen/route.ts
+++ b/web/app/api/block-pool-first-seen/route.ts
@@ -43,6 +43,7 @@ export async function GET(request: Request) {
           $match: {
             height: height,
             $and: [
+              { chain_family: { $exists: false } },
               { pool_name: { $ne: null } },
               { pool_name: { $ne: "" } }
             ]

--- a/web/components/AnalyticsPanel.tsx
+++ b/web/components/AnalyticsPanel.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import ForkTimeline from "./ForkTimeline";
+import { reverseHex } from "@/utils/formatters";
 
 type AnalysisFlag = {
   key?: string;
@@ -23,8 +24,21 @@ interface BlockWithAnalysis {
 
 interface RawMiningNotify {
   pool_name?: string | null;
+  chain_family?: string | null;
   timestamp: string;
   prev_hash: string;
+}
+
+interface AnalysisDataResult {
+  height: number;
+  mining_notifications?: RawMiningNotify[];
+  previous_block?: {
+    hash?: string;
+  } | null;
+}
+
+interface AnalysisDataResponse {
+  results?: AnalysisDataResult[];
 }
 
 export default function AnalyticsPanel({ height }: { height: number }) {
@@ -38,27 +52,25 @@ export default function AnalyticsPanel({ height }: { height: number }) {
     async function load() {
       try {
         setLoading(true);
-        const [blockRes, notifyRes, prevBlockRes] = await Promise.all([
+        const [blockRes, analysisRes] = await Promise.all([
           fetch(`/api/blocks?height=${height}&n=1`, { cache: "no-store" }),
-          fetch(`/api/mining-notify?height=${height}`, { cache: "no-store" }),
-          fetch(`/api/blocks?height=${height - 1}&n=1`, { cache: "no-store" }),
+          fetch(`/api/analysis-data?height=${height}`, { cache: "no-store" }),
         ]);
         const blockData = await blockRes.json();
         const items: BlockWithAnalysis[] = Array.isArray(blockData.blocks) ? blockData.blocks : [];
         const found = items.find((b) => b.height === height) || null;
 
         let notifs: RawMiningNotify[] = [];
-        try {
-          const notifyData = await notifyRes.json();
-          notifs = Array.isArray(notifyData) ? notifyData : [];
-        } catch { /* ignore parse errors */ }
-
         let canonicalHash: string | undefined;
         try {
-          const prevData = await prevBlockRes.json();
-          const prevItems: BlockWithAnalysis[] = Array.isArray(prevData.blocks) ? prevData.blocks : [];
-          const prevBlock = prevItems.find((b) => b.height === height - 1);
-          canonicalHash = prevBlock?.block_hash;
+          const analysisData = await analysisRes.json();
+          const analysisResponse = analysisData as AnalysisDataResponse;
+          const analysisResults: AnalysisDataResult[] = Array.isArray(analysisResponse.results)
+            ? analysisResponse.results
+            : [];
+          const analysisResult = analysisResults.find((result) => result.height === height) || null;
+          notifs = analysisResult?.mining_notifications ?? [];
+          canonicalHash = analysisResult?.previous_block?.hash;
         } catch { /* ignore */ }
 
         if (!cancelled) {
@@ -87,21 +99,37 @@ export default function AnalyticsPanel({ height }: { height: number }) {
     return block.analysis.flags as AnalysisFlag[];
   }, [block]);
 
+  const hasBchTemplate = useMemo(
+    () => miningNotifications.some((notification) => notification.chain_family === "bch"),
+    [miningNotifications]
+  );
+
+  const btcOnlyMiningNotifications = useMemo(
+    () =>
+      miningNotifications.filter(
+        (notification) => notification.chain_family == null || notification.chain_family !== "bch"
+      ),
+    [miningNotifications]
+  );
+
+  const forkTimelineNotifications = useMemo(
+    () =>
+      btcOnlyMiningNotifications.map((notification) => ({
+        ...notification,
+        prev_hash: reverseHex(notification.prev_hash),
+      })),
+    [btcOnlyMiningNotifications]
+  );
+
   if (loading) {
     return (
       <div className="border border-border rounded-md p-3 bg-card text-xs opacity-70">Loading analytics…</div>
     );
   }
 
-  if (!flags || flags.length === 0) {
-    return (
-      <div className="border border-border rounded-md p-3 bg-card text-xs opacity-70">None</div>
-    );
-  }
-
   function renderPrevHashFork() {
-    if (miningNotifications.length === 0) return null;
-    return <ForkTimeline notifications={miningNotifications} canonicalBlockHash={prevBlockHash} />;
+    if (forkTimelineNotifications.length === 0) return null;
+    return <ForkTimeline notifications={forkTimelineNotifications} canonicalBlockHash={prevBlockHash} />;
   }
 
   function renderInvalidTemplates(flag: AnalysisFlag) {
@@ -151,14 +179,27 @@ export default function AnalyticsPanel({ height }: { height: number }) {
 
   return (
     <div className="border border-border rounded-md p-3 bg-card">
-      {flags.map((f, i) => (
-        <div key={`${f.key || i}`}>
-          {f.key === "prev_hash_fork" && renderPrevHashFork()}
-          {f.key === "invalid_coinbase_no_merkle" && renderInvalidTemplates(f)}
+      {hasBchTemplate ? (
+        <div className="mb-3">
+          <span
+            className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300"
+            title="Confirmed BCH template"
+            aria-label="Confirmed BCH template"
+          >
+            Confirmed BCH template
+          </span>
         </div>
-      ))}
+      ) : null}
+      {flags.length === 0 ? (
+        <div className="text-xs opacity-70">None</div>
+      ) : (
+        flags.map((f, i) => (
+          <div key={`${f.key || i}`}>
+            {f.key === "prev_hash_fork" && renderPrevHashFork()}
+            {f.key === "invalid_coinbase_no_merkle" && renderInvalidTemplates(f)}
+          </div>
+        ))
+      )}
     </div>
   );
 }
-
-

--- a/web/lib/db/mining-notify.ts
+++ b/web/lib/db/mining-notify.ts
@@ -39,7 +39,13 @@ export async function getMiningNotifyByHeight(height: number): Promise<MiningNot
 
     // If not in cache, fetch from database
     const records = await prisma.miningNotify.findMany({
-      where: { height: height },
+      where: {
+        height,
+        OR: [
+          { chain_family: null },
+          { chain_family: { isSet: false } },
+        ],
+      },
     });
 
     // Store in cache

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -7,6 +7,7 @@
  */
 export interface StratumV1Data {
   pool_name: string;
+  chain_family?: string;
   timestamp: string;
   job_id: string;
   height: number;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -48,6 +48,7 @@ model MiningNotify {
   id                String   @id @default(auto()) @map("_id") @db.ObjectId
   height            Int
   pool_name         String?
+  chain_family      String?
   coinbase1         String
   coinbase2         String
   merkle_branches   String[]


### PR DESCRIPTION
Resolves #72 

I've been noticing over the past few months that some of the pools that I collect will sometimes send BCH templates to me and this is messing up my fork analysis process in `backend` and also the time-to-first-block visual in `web`.

Seeing this primarily from Headframe, SigmaPool, and Braiins. I'm getting BCH templates from Braiins because of their [Hashpower](https://hashpower.braiins.com/) product. They seem to be farming out their rental orders, at least in-part, to their `stratum.braiins.com:3333` pool hashers and some renters are mining BCH templates and I'm sometimes collecting them.

This PR adds ZMQ to `collector` so that collectors are aware of the current BTC chain tip. If `btc_chain_divergence_threshold` is met while collecting from a pool, then `collector` tries to figure out which chain the template is for; right now I'm only matching/identifying BCH templates by making an API call to https://api.blockchair.com/bitcoin-cash/raw/block to see if the prev_hash in the template belongs to BCH. If it does, it adds a "chain_family=bch" data item to the message doc, or "chain_family=unknown" if it's not BCH. Then I filter these out during `web` visual rendering also `backend` processing.

Might need to refine this process but it's a starting point to stop the bleeding/bad-data from polluting my analysis.